### PR TITLE
#12 switch to sending null instead of info

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -95,7 +95,7 @@ function startPostalJob()
     })
 
     local playerPed = PlayerPedId()
-    NotifyPlayer(t('head_over_to_waypoint'), 'info')
+    NotifyPlayer(t('head_over_to_waypoint'))
     postalJobState.isDoingJob = true
     postalJobState.positionSet.startLocation = GetEntityCoords(playerPed)
 
@@ -171,7 +171,7 @@ function pickupMail()
         message = t('picked_up_mail'),
     })
 
-    NotifyPlayer(t('place_package_in_back_of_van'), 'info')
+    NotifyPlayer(t('place_package_in_back_of_van'))
 
     TARGET.RemoveZone(postalJobState.postalBoxZone)
     RemoveBlip(postalJobState.pickupBlip)
@@ -467,7 +467,7 @@ function spawnGoPostalVehicle()
 end
 
 function endPostalJob()
-    NotifyPlayer(t('you_are_done_with_shift'), 'info')
+    NotifyPlayer(t('you_are_done_with_shift'))
 
     log({
         type = 'success',
@@ -959,7 +959,7 @@ end
 AddEventHandler('onResourceStop', function(resource)
     if resource == GetCurrentResourceName() then
         if (postalJobState.isDoingJob) then
-            NotifyPlayer(t('force_clock_out_script_restart'), 'info', 10000)
+            NotifyPlayer(t('force_clock_out_script_restart'))
             takeOffJobOutfit()
             if (postalJobState.isCarryingBox) then
                 removeBox()

--- a/client_util.lua
+++ b/client_util.lua
@@ -15,10 +15,9 @@ else
 end
 
 ---@param message string text of the notification
----@param type? 'info' | 'warning' | 'success' | 'error', defaults to info
+---@param type? string
 ---@param duration? integer milliseconds notification will remain on screen. Defaults to 5000
 function NotifyPlayer(message, type, duration)
-    type = type or 'info'
     duration = duration or 5000
 
     if (Config.NOTIFY == 'qb') then


### PR DESCRIPTION
different framewoks have different fallback values, but they all handle nil well.

examples:
https://github.com/esx-framework/esx_core/blob/bcc1e876b6b7befa8630ee5fafc605b10dc290d3/%5Bcore%5D/esx_notify/Notify.lua#L28

https://overextended.dev/ox_lib/Modules/Interface/Client/notify

https://github.com/qbcore-framework/qb-core/blob/main/config.lua#L46

Shoutout to Scooter for finding this issue!